### PR TITLE
Adding support for java flight recording

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -8,6 +8,8 @@ Xms: 20
 Xmx: 40
 # path to PanTools jar file; only for development!!!
 jar:
+# prefix to profiling file; only for development!!!
+jfr_prefix:
 # nice priority
 nice:
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -4,12 +4,19 @@ Contains setup logic and common functions for other Snakemake rules.
 
 import sys
 import tempfile
+from datetime import datetime
 
 # Set pantools command with Java heap space.
+jvm_options = f"-Xms{config['Xms']}g -Xmx{config['Xmx']}g"
+
+if config['jfr_prefix']:
+    prefix = f"{config['jfr_prefix']}.{datetime.now().strftime('%y%m%d%H%M%S%f')}"
+    jvm_options = f"-XX:StartFlightRecording=filename={prefix}.jfr,disk=true {jvm_options}"
+
 if config['jar']:
-    pantools = "java -Xms{}g -Xmx{}g -jar {}".format(config['Xms'], config['Xmx'], config['jar'])
+    pantools = f"java {jvm_options} -jar {config['jar']}"
 else:
-    pantools = "pantools -Xms{}g -Xmx{}g".format(config['Xms'], config['Xmx'])
+    pantools = f"pantools {jvm_options}"
 
 if config['nice']: pantools = f"nice -n {config['nice']} {pantools}"
 


### PR DESCRIPTION
As title says. This PR adds an option to the config file for java flight recording and if this is enabled it will write JFR files per pantools run that are formatted like so: `${prefix}.${timestamp}.jfr` where the `${prefix}` is found in the log and the timestamp is a timestamp to the millisecond.